### PR TITLE
Choice of (vl,vp) velocity-space coordinates

### DIFF
--- a/run/gkvp_namelist
+++ b/run/gkvp_namelist
@@ -5,7 +5,8 @@
         z_calc="cf4",
         art_diff=0.1d0,
         init_random=.false.,
-        num_triad_diag=0, &end
+        num_triad_diag=0,
+        vp_coord=1, &end
  &triad mxt = 0, myt = 0/
  &equib equib_type = "analytic", &end
  &run_n inum=%%%,

--- a/src/gkvp_bndry.f90
+++ b/src/gkvp_bndry.f90
@@ -25,6 +25,11 @@ MODULE GKV_bndry
       bndry_vm_buffin, bndry_vm_sendrecv, bndry_vm_buffout, &
       bndry_shifts_m_buffin, bndry_shifts_m_sendrecv, bndry_shifts_m_buffout
 
+!> vp-mu
+  public bndry_shifts_m_e, bndry_shifts_m_f
+!< vp-mu
+
+
 
 CONTAINS
 
@@ -1490,5 +1495,209 @@ CONTAINS
 
   END SUBROUTINE bndry_vm_buffout
 
+!> vp-mu
+!--------------------------------------
+  SUBROUTINE bndry_shifts_m_e( ew, ew_b )
+!--------------------------------------
+!     Shift communications in m direction
+
+    complex(kind=DP), intent(in), &
+      dimension(-nx:nx,0:ny,-nz-nzb:nz-1+nzb,0:nm) :: ew
+    complex(kind=DP), intent(inout), &
+      dimension(-nx:nx,0:ny,-nz-nzb:nz-1+nzb,0-nvb:nm+nvb) :: ew_b
+
+    complex(kind=DP), dimension(:,:,:,:), allocatable :: mb1, mb2
+
+    integer  ::  mx, my, iz, im
+
+      allocate( mb1(-nx:nx,0:ny,-nz:nz-1,1:2*nvb) )
+      allocate( mb2(-nx:nx,0:ny,-nz:nz-1,1:2*nvb) )
+
+      do im = 0, nm
+!$OMP do schedule (dynamic)
+        do iz = -nz, nz-1
+          do my = ist_y, iend_y
+            do mx = -nx, nx
+              ew_b(mx,my,iz,im) = ew(mx,my,iz,im)
+            end do
+          end do
+        end do
+!$OMP end do nowait
+      end do
+
+      call bndry_shifts_m_e_buffin( ew_b, mb1, mb2 )
+      call bndry_shifts_m_e_sendrecv( mb1, mb2 )
+      call bndry_shifts_m_e_buffout( mb2, ew_b )
+
+      deallocate( mb1 )
+      deallocate( mb2 )
+
+
+  END SUBROUTINE bndry_shifts_m_e
+
+!--------------------------------------
+  SUBROUTINE bndry_shifts_m_f( ff )
+!--------------------------------------
+
+    complex(kind=DP), intent(inout), &
+      dimension(-nx:nx,0:ny,-nz-nzb:nz-1+nzb,1-nvb:2*nv+nvb,0-nvb:nm+nvb) :: ff
+
+    complex(kind=DP), dimension(:,:,:,:,:), allocatable :: mb1, mb2
+
+      allocate( mb1(-nx:nx,0:ny,-nz:nz-1,1:2*nv,1:2*nvb) )
+      allocate( mb2(-nx:nx,0:ny,-nz:nz-1,1:2*nv,1:2*nvb) )
+
+!$OMP parallel default (none) &
+!$OMP shared(ff,mb1,mb2) &
+      call bndry_shifts_m_buffin ( ff, mb1, mb2 )
+!$OMP barrier
+!$OMP master
+      call bndry_shifts_m_sendrecv ( mb1, mb2 )
+!$OMP end master
+!$OMP barrier
+      call bndry_shifts_m_buffout ( mb2, ff )
+!$OMP end parallel
+
+      deallocate( mb1 )
+      deallocate( mb2 )
+
+  END SUBROUTINE bndry_shifts_m_f
+
+
+!--------------------------------------
+  SUBROUTINE bndry_shifts_m_e_buffin( ff, mb1, mb2 )
+!--------------------------------------
+!     Shift communications in m direction
+
+    complex(kind=DP), intent(inout), &
+      dimension(-nx:nx,0:ny,-nz-nzb:nz-1+nzb,0-nvb:nm+nvb) :: ff
+    complex(kind=DP), intent(out), &
+      dimension(-nx:nx,0:ny,-nz:nz-1,1:2*nvb) :: mb1, mb2
+
+    integer  ::  mx, my, iz, im
+
+
+!$OMP master
+                                           call clock_sta(1371)
+                                         ! call fapp_start("literm_shifts_bufferin",1371,1)
+!$OMP end master
+
+! --- zero clear is required for rankv = 0, nprocv-1 and rankm = 0, nprocm-1
+      do im = 1, 2*nvb
+!$OMP do schedule (dynamic)
+          do iz = -nz, nz-1
+            do my = ist_y, iend_y
+              do mx = -nx, nx
+                mb2(mx,my,iz,im) = ( 0._DP, 0._DP )
+              end do
+            end do
+          end do
+!$OMP end do nowait
+      end do
+
+!$OMP do schedule (dynamic)
+        do iz = -nz, nz-1
+          do my = ist_y, iend_y
+            do mx = -nx, nx
+              do im = 1, nvb
+                mb1(mx,my,iz,im    ) = ff(mx,my,iz,     im-1)
+                mb1(mx,my,iz,im+nvb) = ff(mx,my,iz,nm-nvb+im)
+              end do
+            end do
+          end do
+        end do
+!$OMP end do nowait
+
+
+!$OMP master
+                                         ! call fapp_stop("literm_shifts_bufferin",1371,1)
+                                           call clock_end(1371)
+!$OMP end master
+
+
+  END SUBROUTINE bndry_shifts_m_e_buffin
+
+
+!--------------------------------------
+  SUBROUTINE bndry_shifts_m_e_sendrecv( mb1, mb2 )
+!--------------------------------------
+!     Shift communications in m direction
+
+    complex(kind=DP), intent(in), &
+      dimension(-nx:nx,0:ny,-nz:nz-1,1:2*nvb) :: mb1
+    complex(kind=DP), intent(inout), &
+      dimension(-nx:nx,0:ny,-nz:nz-1,1:2*nvb) :: mb2
+    integer  ::  slngm
+    integer, dimension(4) :: ireq
+    integer, dimension(MPI_STATUS_SIZE,4) :: istatus
+
+
+      slngm = (2*nx+1)*(ny+1)*(2*nz)* nvb
+
+                                           call clock_sta(1372)
+                                         ! call fapp_start("literm_shifts_sendrecv",1372,1)
+!      call MPI_sendrecv( mb1(-nx,0,-nz,1    ), slngm, MPI_DOUBLE_COMPLEX, imdn, 3, &
+!                         mb2(-nx,0,-nz,nvb+1), slngm, MPI_DOUBLE_COMPLEX, imup, 3, &
+!                         sub_comm_world, status, ierr_mpi )
+!
+!      call MPI_sendrecv( mb1(-nx,0,-nz,nvb+1), slngm, MPI_DOUBLE_COMPLEX, imup, 4, &
+!                         mb2(-nx,0,-nz,1    ), slngm, MPI_DOUBLE_COMPLEX, imdn, 4, &
+!                         sub_comm_world, status, ierr_mpi )
+
+      call MPI_irecv( mb2(-nx,0,-nz,nvb+1), slngm, MPI_DOUBLE_COMPLEX, imup, 3, &
+                      sub_comm_world, ireq(1), ierr_mpi )
+      call MPI_irecv( mb2(-nx,0,-nz,    1), slngm, MPI_DOUBLE_COMPLEX, imdn, 4, &
+                      sub_comm_world, ireq(2), ierr_mpi )
+      call MPI_isend( mb1(-nx,0,-nz,    1), slngm, MPI_DOUBLE_COMPLEX, imdn, 3, &
+                      sub_comm_world, ireq(3), ierr_mpi )
+      call MPI_isend( mb1(-nx,0,-nz,nvb+1), slngm, MPI_DOUBLE_COMPLEX, imup, 4, &
+                      sub_comm_world, ireq(4), ierr_mpi )
+      call MPI_waitall( 4, ireq, istatus, ierr_mpi )
+                                         ! call fapp_stop("literm_shifts_sendrecv",1372,1)
+                                           call clock_end(1372)
+
+
+  END SUBROUTINE bndry_shifts_m_e_sendrecv
+
+
+!--------------------------------------
+  SUBROUTINE bndry_shifts_m_e_buffout( mb2, ff )
+!--------------------------------------
+!     Shift communications in m direction
+
+    complex(kind=DP), intent(in), &
+      dimension(-nx:nx,0:ny,-nz:nz-1,1:2*nvb) :: mb2
+    complex(kind=DP), intent(inout), &
+      dimension(-nx:nx,0:ny,-nz-nzb:nz-1+nzb,0-nvb:nm+nvb) :: ff
+
+    integer  ::  mx, my, iz, im
+
+
+!$OMP master
+                                           call clock_sta(1373)
+                                         ! call fapp_start("literm_shifts_bufferout",1373,1)
+!$OMP end master
+
+!$OMP do schedule (dynamic)
+        do iz = -nz, nz-1
+          do my = ist_y, iend_y
+            do mx = -nx, nx
+              do im = 1, nvb
+                ff(mx,my,iz,-nvb-1+im) = mb2(mx,my,iz,im    )
+                ff(mx,my,iz,nm+im    ) = mb2(mx,my,iz,im+nvb)
+              end do
+            end do
+          end do
+        end do
+!$OMP end do nowait
+
+!$OMP master
+                                         ! call fapp_stop("literm_shifts_bufferout",1373,1)
+                                           call clock_end(1373)
+!$OMP end master
+
+
+  END SUBROUTINE bndry_shifts_m_e_buffout
+!< vp-mu
 
 END MODULE GKV_bndry

--- a/src/gkvp_geom.f90
+++ b/src/gkvp_geom.f90
@@ -1559,6 +1559,7 @@ CONTAINS
 
   END SUBROUTINE geom_set_operators
 
+!> vp-mu
 !--------------------------------------
   SUBROUTINE geom_def_dpp( iz, im, domgdz )
 !--------------------------------------
@@ -1587,6 +1588,7 @@ CONTAINS
 
 
   END SUBROUTINE geom_def_dpp
+!< vp-mu
 
 !--------------------------------------
   SUBROUTINE geom_reset_time(time_shearflow)

--- a/src/gkvp_header.f90
+++ b/src/gkvp_header.f90
@@ -45,7 +45,7 @@ MODULE GKV_header
 
   integer, parameter :: nxw = 20, nyw = 20
   integer, parameter :: nx = 4, global_ny = 1 ! 2/3 de-aliasing rule
-  integer, parameter :: global_nz = 12, global_nv = 24, global_nm = 7
+  integer, parameter :: global_nz = 12, global_nv = 24, global_nm = 31
 
   integer, parameter :: nzb = 2, &  ! the number of ghost grids in z
                         nvb = 2     ! the number of ghost grids in v and m
@@ -153,8 +153,12 @@ MODULE GKV_header
   real(kind=DP), dimension(0:ny)            :: ky
   real(kind=DP), dimension(-nz:nz-1)        :: zz, omg
   real(kind=DP), dimension(1:2*nv)          :: vl
-  real(kind=DP), dimension(0:nm)            :: mu
-  real(kind=DP), dimension(-nz:nz-1,0:nm)   :: vp, mir
+!> vp-mu
+!  real(kind=DP), dimension(0:nm)            :: mu
+!  real(kind=DP), dimension(-nz:nz-1,0:nm)   :: vp, mir
+  real(kind=DP), dimension(-nz:nz-1,0:nm)   :: vp, mir, mu
+  real(kind=DP), dimension(-nz:nz-1,1:2*nv,0:nm) :: dpp ! the operator with 0.5*vl*vp*d/d(vp)
+!< vp-mu
   real(kind=DP), dimension(-nz:nz-1)        :: dvp
   real(kind=DP), dimension(-nz:nz-1)        :: dpara, rootg
 
@@ -195,6 +199,9 @@ MODULE GKV_header
 
   integer :: num_triad_diag
 
+!> vp-mu
+  integer :: vp_coord
+!< vp-mu
 
 !--------------------------------------
 !  Parameters for numerical settings

--- a/src/gkvp_out.f90
+++ b/src/gkvp_out.f90
@@ -1211,7 +1211,10 @@ END SUBROUTINE update_dh
           do iz = -nz, nz-1
             do my = ist_y, iend_y
               do mx = -nx, nx
-                wf(mx,my,iz,iv,im) = mu(im) * omg(iz) * ff(mx,my,iz,iv,im) * j0(mx,my,iz,im)
+!> vp-mu
+!!!                wf(mx,my,iz,iv,im) = mu(im) * omg(iz) * ff(mx,my,iz,iv,im) * j0(mx,my,iz,im)
+                wf(mx,my,iz,iv,im) = mu(iz,im) * omg(iz) * ff(mx,my,iz,iv,im) * j0(mx,my,iz,im)
+!< vp-mu
               end do
             end do
           end do
@@ -1241,7 +1244,10 @@ END SUBROUTINE update_dh
           do iz = -nz, nz-1
             do my = ist_y, iend_y
               do mx = -nx, nx
-                wf(mx,my,iz,iv,im) = vl(iv) * mu(im) * omg(iz) * ff(mx,my,iz,iv,im) * j0(mx,my,iz,im)
+!> vp-mu
+!!!                wf(mx,my,iz,iv,im) = vl(iv) * mu(im) * omg(iz) * ff(mx,my,iz,iv,im) * j0(mx,my,iz,im)
+                wf(mx,my,iz,iv,im) = vl(iv) * mu(iz,im) * omg(iz) * ff(mx,my,iz,iv,im) * j0(mx,my,iz,im)
+!< vp-mu
               end do
             end do
           end do

--- a/src/gkvp_set.f90
+++ b/src/gkvp_set.f90
@@ -107,7 +107,10 @@ CONTAINS
 
     namelist /cmemo/ memo
     namelist /calct/ calc_type, z_bound, z_filt, z_calc, art_diff, &
-                     init_random, num_triad_diag
+!> vp-mu
+!                     init_random, num_triad_diag
+                     init_random, num_triad_diag, vp_coord
+!< vp-mu
     namelist /equib/ equib_type
     namelist /run_n/ inum, ch_res
     namelist /files/ f_log, f_hst, f_phi, f_fxv, f_cnt
@@ -218,6 +221,7 @@ CONTAINS
       write( olog, * ) "# Finite difference scheme in zz : ", trim(z_calc)
       write( olog, * ) "# Artificial diffusion in zz     : ", art_diff
       write( olog, * ) "# Number of triad transfer diag. : ", num_triad_diag
+      write( olog, * ) "# Velocity space coordinate (=1 for vp, others for mu) : ", vp_coord
       write( olog, * ) "# Type of equib. : ", trim(equib_type)
       write( olog, * ) ""
       write( olog, * ) "# Run number = ", inum


### PR DESCRIPTION
Previous GKV code employs (vl,mu) velocity-space coordinates, namely, the parallel velocity and magnetic moment.
New choice of velocity-space coordinate (vl,vp), replacing the perpendicular velocity-space coordinate from the magnetic moment to the perpendicular velocity.

This choice is beneficial when the magnetic field strength significantly varies, like the dipole geometry.

Switching the velocity-space coordinates is done in run/gkvp_namelist:
    vp_coord = 0 # For (vl,mu) coordinates
    vp_coord = 1 # For (vl,vp) coordinates

In the equation, the parallel advection term is modified:
```math
    \frac{\partial}{\partial z}_{(z,v_\parallel,\mu)} \rightarrow \frac{\partial}{\partial z}_{(z,v_\parallel,v_\perp)} + \frac{v_\perp}{2B}\frac{\partial B}{\partial z}\frac{\partial}{\partial v_\perp}_{(z,v_\parallel,v_\perp)}
```

Note that the recent rotating flux-tube implementation, the rotating operator is unchanged,
```math
    \frac{\partial}{\partial t''}_{(z,v_\parallel,\mu)} - \frac{\gamma_E}{\hat{s}} \frac{\partial}{\partial z''}_{(z,v_\parallel,\mu)} \rightarrow  \frac{\partial}{\partial t''}_{(z,v_\parallel,v_\perp)} - \frac{\gamma_E}{\hat{s}} \frac{\partial}{\partial z''}_{(z,v_\parallel,v_\perp)} 
```
because the operators of $\partial_{v_{\perp}}$ from the first ($\partial_{t''}$) and second (\partial_{z''}) terms cancel out. 